### PR TITLE
feat: Compare different performance improvements

### DIFF
--- a/hyperFakeModel/neural-network/PERFORMANCE.md
+++ b/hyperFakeModel/neural-network/PERFORMANCE.md
@@ -1,0 +1,99 @@
+# Performance Tuning
+
+The [official performance tuning guide](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html) described three types of tuning, general, CPU specific and GPU specific improvments.
+
+## Already included improvements
+
+- [Disabling gradient calculation for validation or inference](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#disable-gradient-calculation-for-validation-or-inference)
+
+## Further interesting improvements
+
+- [Enabling asynchronous data loading and augmentation](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#enable-asynchronous-data-loading-and-augmentation)
+- [Utilizing OpenMP](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#utilize-openmp)
+- [Using TZMalloc](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#utilize-openmp)
+- [Reducing floating point precision](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#enable-tensor-cores)
+- [Using CUDA graphs](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#use-cuda-graphs)
+- [Using cuDNN auto-tuner](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#use-cuda-graphs)
+- [Avoiding unnecessary CPU-GPU synchronisation](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html#avoid-unnecessary-cpu-gpu-synchronization)
+
+## Testing Environment
+
+CPU: 9950X3D \
+RAM: 192GB 2666MHZ DDR5 RAM \
+GPU: RTX2070 SUPER
+
+original database: 8_997_754 rows \
+removed zeros: 1_085_890 rows \
+bfs: 2_375_594 rows
+
+We ran the eperiments by executing the manual training, utilizing a fixed hyperparameter set and running 10 training epochs for the bfs function.
+
+```json
+{
+    "hyperparams": {
+        "hidden_dims": [
+            39,
+            21
+        ],
+        "dropouts": [
+            0.03267819348951357,
+            0.02272203322672002
+        ],
+        "lr": 0.004580708150974148,
+        "weight_decay": 1.0540556598931587e-06,
+        "batch_size": 64,
+        "patience": 20,
+        "optimizer": "Adam"
+    },
+    "val_score_optuna": 0.5603743326065578,
+    "val_score_final_training_optuna": 0.5593990597609929,
+    "val_score_training_full_data": 0.5014,
+    "r2_score_training_full_data": 0.4984
+}
+```
+
+## "Default" Settings (before experiment)
+
+- no compilation
+- 0 workers (for data loading)
+- 0 OpenMP Threads
+- no TCMalloc implementation
+- f32 highest precision
+
+## Results
+
+|                  | GPU (jobs=1)  | CPU (jobs=1)  |
+|------------------|---------------|---------------|
+| none (current)   | 20s/it        | 10s/it        |
+| default          | 22s/it        | 10s/it        |
+| max-autotune     | 17s/it        | 10s/it        |
+| reduce-overhead  | 17s/it        | 10s/it        |
+| 1 workers        | 46s/it        | 36s/it        |
+| 2 workers        | 43s/it        | 33s/it        |
+| 4 workers        | 44s/it        | 33s/it        |
+| OpenMP 1 Thread  | not possible  | 7s/it         |
+| OpenMP 2 Threads | not possible  | 7s/it         |
+| OpenMP 4 Threads | not possible  | 7s/it         |
+| TCMalloc         | not possible  | 10s/it        |
+| f32 medium precision | 19s/it    | not possible  |
+| cudnn benchmark  | 20s/it        | not possible  |
+
+The above results are *before* improving the data loading!
+some improvements in data loading (total 4s/it reduction):
+
+- `all_predictions` / `all_targets` lists are now only copied when evaluation finishes => 1s/it reduction
+- CustomData loads data into GPU -> 3s/it reduction
+
+
+## Prerequisites
+
+### OpenMP
+
+OpenMP needs to be installed (included in libgcc). Then set `export OMP_NUM_THREADS=1`
+
+To unset use `unset OMP_NUM_THREADS`
+
+### TCMalloc
+
+TCMalloc is part of googles performance tools. Install with `libgoogle-perftools` or `libgoogle-perftools-dev`.
+Then set `export LD_PRELOAD=<path/to/libtcmalloc.so>:$LD_PRELOAD`

--- a/hyperFakeModel/neural-network/PERFORMANCE.md
+++ b/hyperFakeModel/neural-network/PERFORMANCE.md
@@ -26,7 +26,7 @@ original database: 8_997_754 rows \
 removed zeros: 1_085_890 rows \
 bfs: 2_375_594 rows
 
-We ran the eperiments by executing the manual training, utilizing a fixed hyperparameter set and running 10 training epochs for the bfs function.
+We ran the experiments by executing the manual training, utilizing a fixed hyperparameter set and running 10 training epochs for the bfs function.
 
 ```json
 {

--- a/hyperFakeModel/neural-network/README.md
+++ b/hyperFakeModel/neural-network/README.md
@@ -76,3 +76,11 @@ Options:
                            [x>=-1]
   --help                   Show this message and exit.
 ```
+
+## Performance
+
+We applied the improvements mentioned in the [official performance tuning guide](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html).
+
+We achieved performance improvements of up to 20% for training on GPUs and 30% for training on CPU.
+
+You can read more about that [here](./PERFORMANCE.md)

--- a/hyperFakeModel/neural-network/neural_net_cli.py
+++ b/hyperFakeModel/neural-network/neural_net_cli.py
@@ -101,21 +101,21 @@ def cli():
 @shared_training_options
 @click.option(
     "--trials",
-    default=50,
+    default=20,
     type=click.IntRange(1, None),
     show_default=True,
     help="Number of trials",
 )
 @click.option(
     "--jobs",
-    default=1,
+    default=5,
     type=click.IntRange(-1, None),
     show_default=True,
     help="Number of parallel jobs (-1 for # of CPUs)",
 )
 @click.option(
     "--epochs",
-    default=100,
+    default=50,
     type=click.IntRange(1, None),
     show_default=True,
     help="Number of training epochs",

--- a/hyperFakeModel/neural-network/neural_net_cli.py
+++ b/hyperFakeModel/neural-network/neural_net_cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import click
 import json
 import os
@@ -91,22 +93,29 @@ def cli():
 @cli.command()
 @shared_training_options
 @click.option(
+    "--cpu",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Use CPU for training instead of GPU",
+)
+@click.option(
     "--trials",
-    default=20,
+    default=50,
     type=click.IntRange(1, None),
     show_default=True,
     help="Number of trials",
 )
 @click.option(
     "--jobs",
-    default=5,
+    default=1,
     type=click.IntRange(-1, None),
     show_default=True,
     help="Number of parallel jobs (-1 for # of CPUs)",
 )
 @click.option(
     "--epochs",
-    default=50,
+    default=100,
     type=click.IntRange(1, None),
     show_default=True,
     help="Number of training epochs",
@@ -141,6 +150,7 @@ def cli():
     help="Unique ID of the study",
 )
 def optuna(
+    cpu: bool,
     dbs_dir,
     export_dir,
     func_tag,
@@ -165,6 +175,7 @@ def optuna(
     assert jobs != 0, "Number of parallel jobs must not be 0"
     click.echo(f"Trials: {trials}, Jobs: {jobs}")
     optuna_pipeline(
+        cpu,
         func_tag,
         short_name,
         dbs_dir,

--- a/hyperFakeModel/neural-network/neural_net_cli.py
+++ b/hyperFakeModel/neural-network/neural_net_cli.py
@@ -9,6 +9,13 @@ from neural_network import optuna_pipeline, manual_pipeline
 
 def shared_training_options(func):
     @click.option(
+        "--cpu",
+        is_flag=True,
+        default=False,
+        show_default=True,
+        help="Use CPU for training instead of GPU",
+    )
+    @click.option(
         "--dbs-dir",
         type=click.Path(exists=True),
         default=os.path.normpath(
@@ -92,13 +99,6 @@ def cli():
 
 @cli.command()
 @shared_training_options
-@click.option(
-    "--cpu",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="Use CPU for training instead of GPU",
-)
 @click.option(
     "--trials",
     default=50,
@@ -216,6 +216,7 @@ def optuna(
     help="Number of samples to train on [-1 uses all data]",
 )
 def manual(
+    cpu,
     dbs_dir,
     export_dir,
     func_tag,
@@ -239,6 +240,7 @@ def manual(
     if hyperparams:
         hyperparameters = _read_and_validate_hyperparams(hyperparams)
     manual_pipeline(
+        cpu,
         func_tag,
         short_name,
         dbs_dir,

--- a/hyperFakeModel/neural-network/neural_network.py
+++ b/hyperFakeModel/neural-network/neural_network.py
@@ -692,6 +692,7 @@ def run_optuna_study(
 
 
 def manual_pipeline(
+    cpu: bool,
     func_tags,
     short_names,
     dbs_dir,
@@ -719,7 +720,7 @@ def manual_pipeline(
             X, y = create_sample_data(input_cols=input_cols, output_cols=output_cols)
         identifier = short_name + "_" + datetime.now().strftime("%m%d_%H%M")
         onnx_export_path = os.path.join(export_dir, f"{short_name}.onnx")
-        setup_model_training(identifier, onnx_export_path, X, y, epochs, output_cols, hyperparams)
+        setup_model_training(cpu, identifier, onnx_export_path, X, y, epochs, output_cols, hyperparams)
 
 
 def optuna_pipeline(


### PR DESCRIPTION
Adds cli option `--cpu` to enforce using the cpu

Adds flags to enable different performance improvements:
- enable compilation
- enable async data loading

Updated the `CustomData` class to load data onto the GPU if the device is selected (for the ~3GB database I used this amounted to 400MB on the GPU)

Added PERFORMANCE.md which includes a performance comparison for different improvements.

Added explanation on how to enable OpenMP and TCMalloc